### PR TITLE
fixed geojsonseq file extension

### DIFF
--- a/duckdb_queries/places.sql
+++ b/duckdb_queries/places.sql
@@ -26,7 +26,7 @@ COPY (
         AND bbox.maxx < -122.2477071
         AND bbox.miny > 47.5621587
         AND bbox.maxy < 47.7120663
-    ) TO 'places_seattle.geojsonseq'
+    ) TO 'places_seattle.geojsonl'
 WITH (FORMAT GDAL, DRIVER 'GeoJSONSeq');
 
 -- Tip: Replace the last 2 lines with:


### PR DESCRIPTION
extension should be .geojsonl or .geojsons to help GDAL choose the correct delimiter. 

In my case, duckdb 0.9.1 doesn't proceed, but hits the following error: Error: IO Error: GDAL Error (1): PROJ: proj_create: unrecognized format / unknown name

This is kind of irritating when you're new to duckdb/GDAL and just want to copy/paste the first commands from the docs :)