### PR TITLE
fix: add the statement for loading partitions in Oct 2023 athena setup guide

### DIFF
--- a/athena_setup_queries.sql
+++ b/athena_setup_queries.sql
@@ -12,7 +12,7 @@
 --         so use Athena in us-west-2 for best performance.
 ------------------------------------------------------------------------
 
--- October 2023 Release: 
+-- October 2023 Release uses a unified schema for all themes. There's no need to create separate tables for each theme if you are only interested in the October 2023 Release data.
 
 CREATE EXTERNAL TABLE `overture_2023_10_19_alpha_0`(
   `categories` struct<main:string,alternate:array<string>>, 
@@ -58,6 +58,8 @@ STORED AS PARQUET
 LOCATION
   's3://overturemaps-us-west-2/release/2023-10-19-alpha.0'
 
+
+MSCK REPAIR TABLE `overture_2023_10_19_alpha_0`;
 
 
 -- =====================================================================


### PR DESCRIPTION
Hi, added the partition loading statement for Oct 2023 Release to allow querying from Athena console.

For the record and future searchers, without this you might encrounter a similar error in Athena console:

```
HIVE_CURSOR_ERROR: Failed to read Parquet file: s3://overturemaps-us-west-2/release/2023-10-19-alpha.0/theme=admins/type=administrativeBoundary/part-00020-87dd7d19-acc8-4d4f-a5ba-20b407a79638.c000.zstd.parquet
```

Please let me know if anything else is required. Thank you.