### PR TITLE
Updated README.md to change duckdb adminlevel filter to 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ COPY (
             geometry AS areaGeometry
         FROM admins_view
     ) AS areas ON areas.localityId == admins.id
-    WHERE admins.adminLevel = 2
+    WHERE admins.adminLevel = 1
 ) TO 'countries.geojson'
 WITH (FORMAT GDAL, DRIVER 'GeoJSON');
 ```


### PR DESCRIPTION
Small correction to the DuckDB example which includes a regional level filter (adminlevel=2) instead of a national level (adminlevel=1). As a result, the execution returned more than 3000 rows. With this correction, we indeed have 280 rows returned, making it consistent with the rest of the documentation.