### PR TITLE
Update github action to publish dbb

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -40,13 +40,16 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install boto3
+          pip install boto3 duckdb
 
-      - name: Build releases.json
+      - name: Build releases.json and latest.dbb
         run: cd utils && python3 fetch-releases-from-s3.py
 
       - name: Copy output to publish directory
-        run: mkdir publish && cp utils/releases.json publish/
+        run: |
+          mkdir publish
+          cp utils/releases.json publish/
+          cp utils/latest.dbb publish/
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/overture_releases.yaml
+++ b/overture_releases.yaml
@@ -1,3 +1,7 @@
+- schema: "1.7.0"
+  release: "2025-03-19.1"
+- schema: "1.7.0"
+  release: "2025-03-19.0"
 - schema: "1.6.0"
   release: "2025-02-19.0"
 - schema: "1.5.0"

--- a/utils/fetch-releases-from-s3.py
+++ b/utils/fetch-releases-from-s3.py
@@ -1,19 +1,92 @@
-import boto3, json
+import boto3, duckdb, json
 from botocore import UNSIGNED
 from botocore.config import Config
 
-s3 = boto3.client('s3', config=Config(signature_version=UNSIGNED))
+s3 = boto3.client("s3", config=Config(signature_version=UNSIGNED))
 
-contents = s3.list_objects_v2(Bucket='overturemaps-us-west-2', Delimiter='/', Prefix='release/')
+contents = s3.list_objects_v2(
+    Bucket="overturemaps-us-west-2", Delimiter="/", Prefix="release/"
+)
 
 output = {}
 
-for idx, release in enumerate(sorted(contents.get('CommonPrefixes'), key=lambda x:x.get('Prefix'), reverse = True)):
-    path = release.get('Prefix').split('/')[1]
-    if idx==0:
-        output['latest'] = path
-        output['releases'] = []
-    output['releases'].append(path)
+for idx, release in enumerate(
+    sorted(contents.get("CommonPrefixes"), key=lambda x: x.get("Prefix"), reverse=True)
+):
+    path = release.get("Prefix").split("/")[1]
+    if idx == 0:
+        output["latest"] = path
+        output["releases"] = []
+    output["releases"].append(path)
 
-with open ('releases.json','w') as output_file:
+with open("releases.json", "w") as output_file:
     output_file.write(json.dumps(output, indent=4))
+
+conn = duckdb.connect("latest.dbb")
+
+conn.sql(
+    f"""
+INSTALL spatial;
+LOAD spatial;
+
+CREATE OR REPLACE VIEW address AS (
+  SELECT * FROM read_parquet('s3://overturemaps-us-west-2/release/{output.get("latest")}/theme=addresses/type=address/*.parquet')
+);
+
+CREATE OR REPLACE VIEW bathymetry AS (
+  SELECT * FROM read_parquet('s3://overturemaps-us-west-2/release/{output.get("latest")}/theme=base/type=bathymetry/*.parquet')
+);
+
+CREATE OR REPLACE VIEW building AS (
+  SELECT * FROM read_parquet('s3://overturemaps-us-west-2/release/{output.get("latest")}/theme=buildings/type=building/*.parquet')
+);
+
+CREATE OR REPLACE VIEW building_part AS (
+  SELECT * FROM read_parquet('s3://overturemaps-us-west-2/release/{output.get("latest")}/theme=buildings/type=building_part/*.parquet')
+);
+
+CREATE OR REPLACE VIEW connector AS (
+  SELECT * FROM read_parquet('s3://overturemaps-us-west-2/release/{output.get("latest")}/theme=transportation/type=connector/*.parquet')
+);
+
+CREATE OR REPLACE VIEW division AS (
+  SELECT * FROM read_parquet('s3://overturemaps-us-west-2/release/{output.get("latest")}/theme=divisions/type=division/*.parquet')
+);
+
+CREATE OR REPLACE VIEW division_area AS (
+  SELECT * FROM read_parquet('s3://overturemaps-us-west-2/release/{output.get("latest")}/theme=divisions/type=division_area/*.parquet')
+);
+
+CREATE OR REPLACE VIEW division_boundary AS (
+  SELECT * FROM read_parquet('s3://overturemaps-us-west-2/release/{output.get("latest")}/theme=divisions/type=division_boundary/*.parquet')
+);
+
+CREATE OR REPLACE VIEW infrastructure AS (
+  SELECT * FROM read_parquet('s3://overturemaps-us-west-2/release/{output.get("latest")}/theme=base/type=infrastructure/*.parquet')
+);
+
+CREATE OR REPLACE VIEW land AS (
+  SELECT * FROM read_parquet('s3://overturemaps-us-west-2/release/{output.get("latest")}/theme=base/type=land/*.parquet')
+);
+
+CREATE OR REPLACE VIEW land_cover AS (
+  SELECT * FROM read_parquet('s3://overturemaps-us-west-2/release/{output.get("latest")}/theme=base/type=land_cover/*.parquet')
+);
+
+CREATE OR REPLACE VIEW land_use AS (
+  SELECT * FROM read_parquet('s3://overturemaps-us-west-2/release/{output.get("latest")}/theme=base/type=land_use/*.parquet')
+);
+
+CREATE OR REPLACE VIEW place AS (
+  SELECT * FROM read_parquet('s3://overturemaps-us-west-2/release/{output.get("latest")}/theme=places/type=place/*.parquet')
+);
+
+CREATE OR REPLACE VIEW segment AS (
+  SELECT * FROM read_parquet('s3://overturemaps-us-west-2/release/{output.get("latest")}/theme=transportation/type=segment/*.parquet')
+);
+
+CREATE OR REPLACE VIEW water AS (
+  SELECT * FROM read_parquet('s3://overturemaps-us-west-2/release/{output.get("latest")}/theme=base/type=water/*.parquet')
+);
+"""
+)


### PR DESCRIPTION
Updates the latest release / schema mapping and introduces a lightweight duckdb database that can be attached: 

```sql
load spatial;
attach 'https://labs.overturemaps.org/data/latest.dbb' as overture;
select count(1) from overture.water;
```

```
┌─────────────────┐
│    count(1)     │
│      int64      │
├─────────────────┤
│    55368105     │
│ (55.37 million) │
└─────────────────┘
```