### PR TITLE
[CHORE] Add new release date for schema 1.16.0 (Fixes#520)

### DIFF
--- a/overture_releases.yaml
+++ b/overture_releases.yaml
@@ -1,4 +1,6 @@
 - schema: "1.16.0"
+  release: "2026-04-15.0"
+- schema: "1.16.0"
   release: "2026-03-18.0"
 - schema: "1.16.0"
   release: "2026-02-18.0"


### PR DESCRIPTION
Fixes #520. This PR updates the release schedule in overture_releases.yaml by adding new release entry.

Added release entry for schema "1.16.0" with release "2026-04-15.0".